### PR TITLE
add errors and generics, improvements to memory caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ license = "MIT"
 
 [dependencies]
 smallvec = "1.6"
+fnv = "1.0"

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ let out_port = graph.port(output, DefaultPortType::Audio, "mixbus")?;
 graph.connect(port1, out_port)?;
 graph.connect(port2, out_port)?;
 
-let schedule = graph.compile(output);
+let schedule = graph.compile();
 for entry in schedule {
     let node_name = entry.node;
     // inputs may have multiple buffers to handle.

--- a/readme.md
+++ b/readme.md
@@ -18,24 +18,24 @@ let input1 = graph.node("Input 1");
 let input2 = graph.node("Input 2");
 let output = graph.node("Output");
 
-let in_port1 = graph.port(input1, PortType::Audio, "input-1")?;
-let in_port2 = graph.port(input2, PortType::Audio, "input-1")?;
-let out_port = graph.port(output, PortType::Audio, "mixbus")?;
+let in_port1 = graph.port(input1, DefaultPortType::Audio, "input-1")?;
+let in_port2 = graph.port(input2, DefaultPortType::Audio, "input-1")?;
+let out_port = graph.port(output, DefaultPortType::Audio, "mixbus")?;
 
-graph.connect(port1, out_port);
-graph.connect(port2, out_port);
+graph.connect(port1, out_port)?;
+graph.connect(port2, out_port)?;
 
-let schedule = graph.compile(output).collect::<Vec<_>>();
+let schedule = graph.compile(output);
 for entry in schedule {
-    let node_name = graph.node_name(entry.node).unwrap();
+    let node_name = entry.node;
     // inputs may have multiple buffers to handle.
-    for (port, buffers) in entry.inputs {
+    for (port_name, buffers) in entry.inputs {
         for b in buffers {
             // ... 
         }
     }
     // outputs have exactly one buffer they write to
-    for (port, buf) in entry.outputs {
+    for (port_name, buf) in entry.outputs {
         // ... 
     }
 }
@@ -43,7 +43,7 @@ for entry in schedule {
 
 ## Constraints:
 
-- Ports are typed, `PortType::Audio` or `PortType::Event`. Ports must be connected to ports of the same type.
+- Ports are typed, and only ports of the same type can be connected. By default there is the `DefaultPortType` enum which has `Audio` and `Event`, but you may define your own types if you wish.
 - Ports can be bidirectional. This is a quirk of the current implementation, but don't rely on it.
 - Delay compensation is currently unsound, it will result in invalid schedules.
-- Cycles are not supported.
+- Cycles are not supported, and and error will be returned if tried. (However, cycle detection is currently broken atm).

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Work in progress audio graph implementation
 - The graph uses an intermediate representation of nodes in a directed graph
 - Buffers are abstract identified by indices
 - The graph is "compiled" into a schedule, containing buffer allocations and process order
-- Delay compensation is added to each necessary input buffer inside the schedule
+- Delay compensation is automatically added to each needed input buffer inside the schedule
 - The graph supports one-to-many and many-to-one connections
 - The graph has built-in safeguards like cycle detection
 - Multi-threaded schedules can be produced using any given number of threads

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,14 +507,12 @@ where
             if node == src {
                 return Err(Error::Cycle);
             }
-            queue.extend(self.dependents(node).filter(|n| {
-                if queued.contains(n) {
-                    false
-                } else {
-                    queued.insert(*n);
-                    true
+            for dependent in self.dependents(node) {
+                if !queued.contains(&dependent) {
+                    queue.push_back(dependent);
+                    queued.insert(dependent);
                 }
-            }));
+            }
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 use smallvec::smallvec as vec;
 use smallvec::SmallVec;
+use std::fmt::Debug;
 use std::{
     borrow::Borrow,
     collections::{HashMap, HashSet, VecDeque},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Error {
     NodeDoesNotExist,
     PortDoesNotExist,
@@ -13,12 +14,47 @@ pub enum Error {
     ConnectionDoesNotExist,
     RefDoesNotExist,
     InvalidPortType,
+    DstPortAlreadyConnected,
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::NodeDoesNotExist => write!(f, "Audio graph node does not exist"),
+            Error::PortDoesNotExist => write!(f, "Audio graph port does not exist"),
+            Error::Cycle => write!(f, "Audio graph cycle detected"),
+            Error::ConnectionDoesNotExist => write!(f, "Audio graph connection does not exist"),
+            Error::RefDoesNotExist=> write!(f, "Audio graph reference does not exist"),
+            Error::InvalidPortType => write!(f, "Cannot connect audio graph ports. Ports are a different type"),
+            Error::DstPortAlreadyConnected => write!(f, "Cannot connect audio graph ports. The destination port is already connected to another port"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum NodeIdent<T: Debug + Clone> {
+    DelayComp(PortType),
+    User(T),
+}
+
+#[derive(Debug, Clone)]
+pub enum PortIdent<T: Debug + Clone> {
+    DelayComp,
+    User(T),
 }
 
 type Vec<T> = SmallVec<[T; 16]>;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct NodeRef(usize);
+
+impl From<NodeRef> for usize {
+    fn from(n: NodeRef) -> Self {
+        n.0
+    }
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct PortRef(usize);
@@ -50,22 +86,54 @@ struct BufferAllocator {
     audio_buffer_stack: Vec<usize>,
 }
 
+impl BufferAllocator {
+    fn clear(&mut self) {
+        self.event_buffer_count = 0;
+        self.audio_buffer_count = 0;
+        self.event_buffer_stack.clear();
+        self.audio_buffer_stack.clear();
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum PortType {
     Audio,
     Event,
 }
 
-#[derive(Default)]
-pub struct Graph {
+#[derive(Clone)]
+pub struct Graph<N, P>
+where
+    N: Debug + Clone,
+    P: Debug + Clone,
+{
     edges: Vec<Vec<Edge>>,
     ports: Vec<Vec<PortRef>>,
     delays: Vec<u64>,
     port_data: Vec<(NodeRef, PortType)>,
-    port_names: Vec<String>,
-    node_names: Vec<String>,
+    port_identifiers: Vec<PortIdent<P>>,
+    node_identifiers: Vec<NodeIdent<N>>,
     free_nodes: Vec<NodeRef>,
     free_ports: Vec<PortRef>,
+}
+
+impl<N, P> Default for Graph<N, P>
+where
+    N: Debug + Clone,
+    P: Debug + Clone,
+{
+    fn default() -> Self {
+        Self {
+            edges: Vec::new(),
+            ports: Vec::new(),
+            delays: Vec::new(),
+            port_data: Vec::new(),
+            port_identifiers: Vec::new(),
+            node_identifiers: Vec::new(),
+            free_nodes: Vec::new(),
+            free_ports: Vec::new(),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -101,47 +169,87 @@ impl BufferAllocator {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct Scheduled {
-    pub node: NodeRef,
-    pub inputs: Vec<(PortRef, Vec<Buffer>)>,
-    pub outputs: Vec<(PortRef, Buffer)>,
+#[derive(Default)]
+pub struct MemCache<N, P>
+where
+    N: Debug + Clone,
+    P: Debug + Clone,
+{
+    cycle_check_stack: Vec<PortRef>,
+    delay_comp_graph: Option<Graph<N, P>>,
+    all_latencies: Vec<Option<u64>>,
+    delays: HashMap<Edge, (NodeRef, u64)>,
+    allocator: BufferAllocator,
+    input_assignments: HashMap<(NodeRef, PortRef), Vec<Buffer>>,
+    output_assignments: HashMap<(NodeRef, PortRef), (Buffer, usize)>,
+    scheduled_nodes: Vec<NodeRef>,
 }
 
-impl Graph {
-    pub fn node(&mut self, name: &str) -> NodeRef {
+#[derive(Clone, Debug)]
+pub struct Scheduled<N, P>
+where
+    N: Debug + Clone,
+    P: Debug + Clone,
+{
+    pub node: NodeIdent<N>,
+    pub inputs: Vec<(PortIdent<P>, Vec<Buffer>)>,
+    pub outputs: Vec<(PortIdent<P>, Buffer)>,
+}
+
+impl<N, P> Graph<N, P>
+where
+    N: Debug + Clone,
+    P: Debug + Clone,
+{
+    #[inline]
+    pub fn node(&mut self, ident: N) -> NodeRef {
+        self.node_(NodeIdent::User(ident))
+    }
+
+    fn node_(&mut self, ident: NodeIdent<N>) -> NodeRef {
         if let Some(node) = self.free_nodes.pop() {
             let id = node.0;
             self.edges[id].clear();
             self.ports[id].clear();
             self.delays[id] = 0;
-            self.node_names[id] = name.to_owned();
+            self.node_identifiers[id] = ident;
             node
         } else {
             let id = self.node_count();
             self.edges.push(vec![]);
             self.ports.push(vec![]);
             self.delays.push(0);
-            self.node_names.push(name.to_owned());
+            self.node_identifiers.push(ident);
             NodeRef(id)
         }
     }
 
-    pub fn port(&mut self, node: NodeRef, type_: PortType, name: &str) -> Result<PortRef, Error> {
+    #[inline]
+    pub fn port(&mut self, node: NodeRef, type_: PortType, ident: P) -> Result<PortRef, Error> {
+        self.port_(node, type_, PortIdent::User(ident))
+    }
+
+    fn port_(
+        &mut self,
+        node: NodeRef,
+        type_: PortType,
+        ident: PortIdent<P>,
+    ) -> Result<PortRef, Error> {
         if node.0 < self.node_count() && !self.free_nodes.contains(&node) {
-            let port = self
-                .free_ports
-                .pop()
-                .or_else(|| {
-                    self.port_data.push((node, type_));
-                    self.port_names.push(Default::default());
-                    Some(PortRef(self.port_count() - 1))
-                })
-                .unwrap();
-            self.ports[node.0].push(port);
-            self.port_data[port.0] = (node, type_);
-            self.port_names[port.0] = name.to_owned();
-            Ok(port)
+            if let Some(port) = self.free_ports.pop() {
+                self.ports[node.0].push(port);
+                self.port_data[port.0] = (node, type_);
+                self.port_identifiers[port.0] = ident;
+                Ok(port)
+            } else {
+                let port = PortRef(self.port_count());
+
+                self.ports[node.0].push(port);
+                self.port_data.push((node, type_));
+                self.port_identifiers.push(ident);
+
+                Ok(port)
+            }
         } else {
             Err(Error::NodeDoesNotExist)
         }
@@ -177,10 +285,26 @@ impl Graph {
         Ok(())
     }
 
-    pub fn connect(&mut self, src: PortRef, dst: PortRef) -> Result<(), Error> {
+    pub fn connect(
+        &mut self,
+        src: PortRef,
+        dst: PortRef,
+        mem_cache: &mut MemCache<N, P>,
+    ) -> Result<(), Error> {
         self.port_check(src)?;
         self.port_check(dst)?;
-        self.cycle_check(src, dst)?;
+        self.cycle_check(src, dst, mem_cache)?;
+
+        for edge in self.incoming(dst) {
+            if edge.src_port == src {
+                // These two ports are already connected.
+                return Ok(());
+            } else {
+                // Multiple sources cannot merge into the same destination port.
+                return Err(Error::DstPortAlreadyConnected);
+            }
+        }
+
         let (src_node, src_type) = self.port_data[src.0];
         let (dst_node, dst_type) = self.port_data[dst.0];
         if src_type != dst_type {
@@ -193,6 +317,8 @@ impl Graph {
             dst_port: dst,
             type_: src_type,
         };
+
+        /* Maybe use the log crate for this to avoid polluting the user's output?
         println!(
             "connection {}.{} to {}.{} with edge: {:?}",
             self.node_name(src_node).unwrap(),
@@ -201,6 +327,8 @@ impl Graph {
             self.port_name(dst).unwrap(),
             edge
         );
+        */
+
         self.edges[src_node.0].push(edge);
         self.edges[dst_node.0].push(edge);
         Ok(())
@@ -227,14 +355,30 @@ impl Graph {
         Ok(())
     }
 
-    pub fn port_name(&self, port: PortRef) -> Result<&'_ str, Error> {
+    pub fn port_ident(&self, port: PortRef) -> Result<&'_ PortIdent<P>, Error> {
         self.port_check(port)?;
-        Ok(&self.port_names[port.0])
+        Ok(&self.port_identifiers[port.0])
     }
 
-    pub fn node_name(&self, node: NodeRef) -> Result<&'_ str, Error> {
+    pub fn node_ident(&self, node: NodeRef) -> Result<&'_ NodeIdent<N>, Error> {
         self.node_check(node)?;
-        Ok(&self.node_names[node.0])
+        Ok(&self.node_identifiers[node.0])
+    }
+
+    pub fn node_check(&self, n: NodeRef) -> Result<(), Error> {
+        if n.0 < self.node_count() && !self.free_nodes.contains(&n) {
+            Ok(())
+        } else {
+            Err(Error::NodeDoesNotExist)
+        }
+    }
+
+    pub fn port_check(&self, p: PortRef) -> Result<(), Error> {
+        if p.0 < self.port_count() && !self.free_ports.contains(&p) {
+            Ok(())
+        } else {
+            Err(Error::PortDoesNotExist)
+        }
     }
 
     fn node_count(&self) -> usize {
@@ -245,29 +389,22 @@ impl Graph {
         self.port_data.len()
     }
 
-    fn node_check(&self, n: NodeRef) -> Result<(), Error> {
-        if n.0 < self.node_count() && !self.free_nodes.contains(&n) {
-            Ok(())
-        } else {
-            Err(Error::NodeDoesNotExist)
-        }
-    }
+    fn cycle_check(
+        &self,
+        src: PortRef,
+        dst: PortRef,
+        mem_cache: &mut MemCache<N, P>,
+    ) -> Result<(), Error> {
+        mem_cache.cycle_check_stack.clear();
+        mem_cache.cycle_check_stack.push(src);
 
-    fn port_check(&self, p: PortRef) -> Result<(), Error> {
-        if p.0 < self.port_count() && !self.free_ports.contains(&p) {
-            Ok(())
-        } else {
-            Err(Error::PortDoesNotExist)
-        }
-    }
-
-    fn cycle_check(&self, src: PortRef, dst: PortRef) -> Result<(), Error> {
-        let mut stack: Vec<PortRef> = vec![src];
-        while let Some(src) = stack.pop() {
+        while let Some(src) = mem_cache.cycle_check_stack.pop() {
             if src == dst {
                 return Err(Error::Cycle);
             }
-            stack.extend(self.outgoing(src).map(|e| e.dst_port));
+            mem_cache
+                .cycle_check_stack
+                .extend(self.outgoing(src).map(|e| e.dst_port));
         }
         Ok(())
     }
@@ -324,7 +461,7 @@ impl Graph {
         })
     }
 
-    fn walk_mut(&mut self, root: NodeRef, mut f: impl FnMut(&mut Graph, NodeRef)) {
+    fn walk_mut(&mut self, root: NodeRef, mut f: impl FnMut(&mut Graph<N, P>, NodeRef)) {
         let mut queue = VecDeque::new();
         let mut visited: HashSet<NodeRef> = HashSet::new();
         queue.push_back(root);
@@ -344,17 +481,20 @@ impl Graph {
         }
     }
 
-    pub fn compile(&mut self, root: NodeRef) -> impl Iterator<Item = Scheduled> + '_ {
-        let mut all_latencies: Vec<Option<u64>> = vec![None; self.node_count()];
-        let mut delays: HashMap<Edge, (NodeRef, u64)> = Default::default();
-        let mut solve_latency_requirements = |graph: &mut Graph, node: NodeRef| {
+    pub fn compile(
+        &mut self,
+        root: NodeRef,
+        schedule: &mut Vec<Scheduled<N, P>>,
+        mem_cache: &mut MemCache<N, P>,
+    ) {
+        let mut solve_latency_requirements = |graph: &mut Graph<N, P>, node: NodeRef| {
             let _deps = graph.dependencies(node).collect::<Vec<_>>();
             let latencies = graph
                 .dependencies(node)
-                .map(|n| all_latencies[n.0].unwrap() + graph.delays[n.0])
+                .map(|n| mem_cache.all_latencies[n.0].unwrap() + graph.delays[n.0])
                 .collect::<Vec<_>>();
             let max_latency = latencies.iter().max().copied().or(Some(0));
-            all_latencies[node.0] = max_latency;
+            mem_cache.all_latencies[node.0] = max_latency;
             let mut insertions: Vec<NodeRef> = vec![];
             for (dep, latency) in graph
                 .dependencies(node)
@@ -370,24 +510,29 @@ impl Graph {
                     if compensation == 0 {
                         continue;
                     }
-                    if let Some((node, delay)) = delays.get_mut(&edge) {
+                    if let Some((node, delay)) = mem_cache.delays.get_mut(&edge) {
                         *delay = compensation;
                         graph.delays[node.0] = compensation;
                     } else {
                         graph.remove_edge(edge).unwrap();
-                        let delay_node = graph.node(&format!(
-                            "delay-{}.{}-{}.{}",
-                            &graph.node_names[edge.src_node.0],
-                            &graph.port_names[edge.src_port.0],
-                            &graph.node_names[edge.dst_node.0],
-                            &graph.port_names[edge.dst_port.0],
-                        ));
-                        let delay_input = graph.port(delay_node, edge.type_, "input").unwrap();
-                        let delay_output = graph.port(delay_node, edge.type_, "output").unwrap();
-                        graph.connect(edge.src_port, delay_input).unwrap();
-                        graph.connect(delay_output, edge.dst_port).unwrap();
+
+                        let delay_node = graph.node_(NodeIdent::DelayComp(edge.type_));
+
+                        let delay_input = graph
+                            .port_(delay_node, edge.type_, PortIdent::DelayComp)
+                            .unwrap();
+                        let delay_output = graph
+                            .port_(delay_node, edge.type_, PortIdent::DelayComp)
+                            .unwrap();
+
+                        graph
+                            .connect(edge.src_port, delay_input, mem_cache)
+                            .unwrap();
+                        graph
+                            .connect(delay_output, edge.dst_port, mem_cache)
+                            .unwrap();
                         graph.delays[delay_node.0] = compensation;
-                        delays.insert(edge, (delay_node, compensation));
+                        mem_cache.delays.insert(edge, (delay_node, compensation));
                         insertions.push(delay_node);
                     }
                 }
@@ -395,71 +540,106 @@ impl Graph {
             insertions.into_iter()
         };
 
-        let mut allocator = BufferAllocator::default();
-        let mut input_assignments: HashMap<(NodeRef, PortRef), Vec<Buffer>> = Default::default();
-        let mut output_assignments: HashMap<(NodeRef, PortRef), (Buffer, usize)> =
-            Default::default();
-
-        let mut solve_buffer_requirements = |graph: &Graph, node: NodeRef| {
+        let mut solve_buffer_requirements = |graph: &Graph<N, P>, node: NodeRef| {
             for port in &graph.ports[node.0] {
                 let (_, type_) = graph.port_data[port.0];
                 for output in graph.outgoing(*port) {
-                    let (buffer, count) = output_assignments
+                    let (buffer, count) = mem_cache
+                        .output_assignments
                         .entry((node, *port))
-                        .or_insert((allocator.acquire(type_), 0));
+                        .or_insert((mem_cache.allocator.acquire(type_), 0));
                     *count += 1;
-                    input_assignments
+                    mem_cache
+                        .input_assignments
                         .entry((output.dst_node, output.dst_port))
                         .or_insert(vec![])
                         .push(*buffer);
                 }
                 for input in graph.incoming(*port) {
-                    let (buffer, count) = output_assignments
+                    let (buffer, count) = mem_cache
+                        .output_assignments
                         .get_mut(&(input.src_node, input.src_port))
                         .expect("no output buffer assigned");
                     *count -= 1;
                     if *count == 0 {
-                        allocator.release(*buffer);
+                        mem_cache.allocator.release(*buffer);
                     }
                 }
             }
         };
 
-        let mut schedule: Vec<NodeRef> = vec![];
-        self.walk_mut(root, |graph, node| {
-            println!("compiling {}", graph.node_name(node).unwrap());
+        schedule.clear();
+
+        mem_cache.all_latencies.clear();
+        mem_cache.all_latencies.resize(self.node_count(), None);
+        mem_cache.delays.clear();
+
+        mem_cache.allocator.clear();
+        mem_cache.input_assignments.clear();
+        mem_cache.output_assignments.clear();
+
+        mem_cache.scheduled_nodes.clear();
+
+        // This is arguably quite expensive, but the reason is that we don't want to add any delay
+        // compensation nodes to the user's graph (We only want to add them to the schedule).
+        // The fact that we're memory caching the previous graph should help some.
+        let mut delay_comp_graph =
+            if let Some(mut delay_comp_graph) = mem_cache.delay_comp_graph.take() {
+                delay_comp_graph = self.clone();
+                delay_comp_graph
+            } else {
+                self.clone()
+            };
+
+        delay_comp_graph.walk_mut(root, |graph, node| {
+            // Maybe use the log crate for this to avoid polluting the user's output?
+            // println!("compiling {}", graph.node_name(node).unwrap());
+
             let insertions = solve_latency_requirements(graph, node);
             for insertion in insertions {
                 solve_buffer_requirements(graph, insertion);
-                schedule.push(insertion);
+                mem_cache.scheduled_nodes.push(insertion);
             }
             solve_buffer_requirements(graph, node);
-            schedule.push(node);
+            mem_cache.scheduled_nodes.push(node);
         });
 
-        schedule.into_iter().rev().map(move |node| {
-            let inputs: Vec<(PortRef, Vec<Buffer>)> = self.ports[node.0]
-                .iter()
-                .filter_map(|port| {
-                    input_assignments
-                        .get(&(node, *port))
-                        .map(|buffers| (*port, buffers.clone()))
-                })
-                .collect::<Vec<_>>();
-            let outputs = self.ports[node.0]
-                .iter()
-                .filter_map(|port| {
-                    output_assignments
-                        .get(&(node, *port))
-                        .map(|(buffer, _)| (*port, *buffer))
-                })
-                .collect::<Vec<_>>();
-            Scheduled {
-                node,
-                inputs,
-                outputs,
-            }
-        })
+        *schedule = mem_cache
+            .scheduled_nodes
+            .into_iter()
+            .rev()
+            .map(move |node| {
+                let node_ident = delay_comp_graph.node_identifiers[node.0].clone();
+
+                let inputs: Vec<(PortIdent<P>, Vec<Buffer>)> = delay_comp_graph.ports[node.0]
+                    .iter()
+                    .filter_map(|port| {
+                        mem_cache
+                            .input_assignments
+                            .get(&(node, *port))
+                            .map(|buffers| {
+                                (delay_comp_graph.port_identifiers[port.0], buffers.clone())
+                            })
+                    })
+                    .collect::<Vec<_>>();
+                let outputs: Vec<(PortIdent<P>, Buffer)> = delay_comp_graph.ports[node.0]
+                    .iter()
+                    .filter_map(|port| {
+                        mem_cache
+                            .output_assignments
+                            .get(&(node, *port))
+                            .map(|(buffer, _)| (delay_comp_graph.port_identifiers[port.0], *buffer))
+                    })
+                    .collect::<Vec<_>>();
+                Scheduled {
+                    node: node_ident,
+                    inputs,
+                    outputs,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        mem_cache.delay_comp_graph = Some(delay_comp_graph);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub enum PortIdent<T: Debug + Clone> {
     User(T),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
 pub struct NodeRef(usize);
 
 impl From<NodeRef> for usize {
@@ -55,7 +55,7 @@ impl From<NodeRef> for usize {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
 pub struct PortRef(usize);
 impl Borrow<usize> for NodeRef {
     fn borrow(&self) -> &'_ usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,16 +458,28 @@ where
         Ok(&self.node_identifiers[node.0])
     }
 
-    pub fn node_check(&self, n: NodeRef) -> Result<(), Error> {
-        if n.0 < self.node_count() && !self.free_nodes.contains(&n) {
+    pub fn set_port_ident(&mut self, port: PortRef, ident: P) -> Result<(), Error> {
+        self.port_check(port)?;
+        self.port_identifiers[port.0] = PortIdent::User(ident);
+        Ok(())
+    }
+
+    pub fn set_node_ident(&mut self, node: NodeRef, ident: N) -> Result<(), Error> {
+        self.node_check(node)?;
+        self.node_identifiers[node.0] = NodeIdent::User(ident);
+        Ok(())
+    }
+
+    pub fn node_check(&self, node: NodeRef) -> Result<(), Error> {
+        if node.0 < self.node_count() && !self.free_nodes.contains(&node) {
             Ok(())
         } else {
             Err(Error::NodeDoesNotExist)
         }
     }
 
-    pub fn port_check(&self, p: PortRef) -> Result<(), Error> {
-        if p.0 < self.port_count() && !self.free_ports.contains(&p) {
+    pub fn port_check(&self, port: PortRef) -> Result<(), Error> {
+        if port.0 < self.port_count() && !self.free_ports.contains(&port) {
             Ok(())
         } else {
             Err(Error::PortDoesNotExist)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl Borrow<usize> for PortRef {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-struct Edge<PT: Debug + Clone + PortType + PartialEq> {
+struct Edge<PT: PortType + PartialEq> {
     src_node: NodeRef,
     src_port: PortRef,
     dst_node: NodeRef,
@@ -66,7 +66,7 @@ struct Edge<PT: Debug + Clone + PortType + PartialEq> {
     type_: PT,
 }
 
-struct BufferAllocator<PT: Debug + Clone + PortType + PartialEq> {
+struct BufferAllocator<PT: PortType + PartialEq> {
     buffer_count_stacks: Vec<(usize, Vec<usize>)>,
     _phantom_port_type: PhantomData<PT>,
 }
@@ -123,7 +123,7 @@ pub struct Graph<N, P, PT>
 where
     N: Debug + Clone,
     P: Debug + Clone,
-    PT: Debug + Clone + PortType + PartialEq,
+    PT: PortType + PartialEq,
 {
     edges: Vec<Vec<Edge<PT>>>,
     edge_delay_comps: FnvHashMap<Edge<PT>, u64>,
@@ -142,7 +142,7 @@ impl<N, P, PT> Default for Graph<N, P, PT>
 where
     N: Debug + Clone,
     P: Debug + Clone,
-    PT: Debug + Clone + PortType + PartialEq,
+    PT: PortType + PartialEq,
 {
     fn default() -> Self {
         Self {
@@ -161,12 +161,12 @@ where
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct Buffer<PT: Debug + Clone + PortType + PartialEq> {
+pub struct Buffer<PT: PortType + PartialEq> {
     index: usize,
     type_: PT,
 }
 
-impl<PT: Debug + Clone + PortType + PartialEq> BufferAllocator<PT> {
+impl<PT: PortType + PartialEq> BufferAllocator<PT> {
     fn acquire(&mut self, type_: PT) -> Buffer<PT> {
         let type_index = type_.into_index();
         let (count, stack) = &mut self.buffer_count_stacks[type_index];
@@ -194,7 +194,7 @@ pub struct HeapStore<N, P, PT>
 where
     N: Debug + Clone,
     P: Debug + Clone,
-    PT: Debug + Clone + PortType + PartialEq,
+    PT: PortType + PartialEq,
 {
     walk_queue: Option<VecDeque<NodeRef>>,
     walk_indegree: Option<FnvHashMap<NodeRef, usize>>,
@@ -215,7 +215,7 @@ impl<N, P, PT> Default for HeapStore<N, P, PT>
 where
     N: Debug + Clone,
     P: Debug + Clone,
-    PT: Debug + Clone + PortType + PartialEq,
+    PT: PortType + PartialEq,
 {
     fn default() -> Self {
         Self {
@@ -239,7 +239,7 @@ pub struct Scheduled<N, P, PT>
 where
     N: Debug + Clone,
     P: Debug + Clone,
-    PT: Debug + Clone + PortType + PartialEq,
+    PT: PortType + PartialEq,
 {
     pub node: N,
     pub inputs: Vec<(P, Vec<(Buffer<PT>, u64)>)>,
@@ -250,7 +250,7 @@ impl<N, P, PT> Graph<N, P, PT>
 where
     N: Debug + Clone,
     P: Debug + Clone,
-    PT: Debug + Clone + PortType + PartialEq,
+    PT: PortType + PartialEq,
 {
     pub fn node(&mut self, ident: N) -> NodeRef {
         if let Some(node) = self.free_nodes.pop() {


### PR DESCRIPTION
There are quite a few changes I made to have this work better with the Meadowlark project:

- Added `DstPortAlreadyConnected` error type, which is returned when trying to connect a source port to a destination port that is already connected to another source port. I also made `Error` a proper error type.
- Made `PortType` a generic trait, which will allow me to define different types of audio and event buffers for Meadowlark.
- Changed "node name" and "port name" to instead be user-defined generic types. This is because I want to reference my nodes and ports by (type, index) in Meadowlark instead of by name.
- Changed `HashMap` and `HashSet` to instead use `FnvHashMap` and `FnvHashSet` because it is way faster when using integer keys.
- Added a heap memory cache. The purpose of this is to keep all temporary heap-allocated stuff in memory to be re-used. This should greatly improve performance in larger graphs.
- Made a change to how delay compensation works. I don't want the delay compensation nodes to actually be added to the graph, only to the schedule. To achieve this, we clone the graph into a temporary graph inside the `compile()` method. This is arguably quite an expensive operation, but having the heap-allocated memory cached should help with this some.

Also, cycle detection doesn't seem to be working correctly. I'm not sure how to fix it.