### PR TITLE
add extra delay comp info, fix stack overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ license = "MIT"
 [dependencies]
 smallvec = "1.6"
 fnv = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/prototype/graphviz.stanza
+++ b/prototype/graphviz.stanza
@@ -1,0 +1,43 @@
+defpackage audio-graph/graphviz : 
+  import core
+  import collections
+  import audio-graph/main
+
+
+defn print-port-list (ps:Seqable<Port>) : 
+  val ps* = to-seq(ps)
+  let loop (first?:True|False = true) :
+    if not empty?(ps*) : 
+      print("|") when not first?
+      val id = port-id(next(ps*))
+      print("<%_> P%_" % [id, id])
+      loop(false)
+  ; for p in ps do : 
+  ;   print("|<%_> %_" % [port-id(p), port-id(p)])
+
+defn print-node (node:Node) : 
+  print("node%_ [label=\"{N%_}|{{" % [node-id(node), node-id(node)])
+  print-port-list(inputs(node))
+  print("}|{%_ ms}|{" % [latency(node)])
+  print-port-list(outputs(node))
+  print("}}|{}\"]\n")
+
+defn print-edge (edge:Edge) :
+  println("node%_:%_ -> node%_:%_" % [
+    src-node(edge), src-port(edge)
+    dst-node(edge), dst-port(edge)
+  ])
+
+public defn print-graphviz (nodes:Tuple<Node>, edges:Tuple<Edge>) : 
+  val ob = StringBuffer()
+  defn driver () : 
+    println("digraph G {")
+    within indented() : 
+      println("node [shape=Mrecord];")
+      do(print-node, nodes)
+      do(print-edge, edges)
+    println("}")
+
+  with-output-stream(ob,driver)
+  println(to-string(ob))
+

--- a/prototype/main.stanza
+++ b/prototype/main.stanza
@@ -1,0 +1,392 @@
+defpackage audio-graph/main : 
+  import core
+  import collections
+
+; TODOS : 
+;
+; - Uphold preconditiong: valid edges passed into input
+;   a) src port must be output, dst port must be input
+;   b) src/dst ports must exist
+;   c) src/dst nodes must exist
+; 
+; - Uphold precondition: graph is acyclic
+; 
+
+;==============================================================================
+;=========================== Output Data ======================================
+;==============================================================================
+
+public deftype ScheduleEntry
+public defstruct ScheduledNode <: ScheduleEntry : 
+  node-id:Int
+  input-buffers:Tuple<BufferAssignment>
+  output-buffers:Tuple<BufferAssignment>
+  latency:Double  ; kept around for graphviz print
+with : 
+  printer => true
+
+public defstruct InsertedDelay <: ScheduleEntry : 
+  edge:Edge
+  delay:Double
+  input-buffer:False|Int with : 
+    default => false
+    updater => sub-input-buffer
+  output-buffer:False|Int with : 
+    default => false
+    updater => sub-output-buffer
+with : 
+  printer => true
+
+public defn edge-id (d:InsertedDelay) : 
+  edge-id(edge(d))
+
+public defstruct InsertedSum <: ScheduleEntry : 
+  input-buffers:Tuple<Int>
+  output-buffer:Int 
+with : 
+  printer => true
+
+public defstruct CompiledSchedule : 
+  schedule:Tuple<ScheduleEntry>
+  delays:Tuple<InsertedDelay>
+  num-buffers:Tuple<[Int, Int]>
+
+public defstruct BufferAssignment <: Equalable : 
+  buffer-id:Int
+  port-id:Int
+  should-clear:True|False
+  type:Int
+with : 
+  printer => true
+  equalable => true
+
+defn sub-buffers (delay:InsertedDelay, input:False|Int, output:False|Int) : 
+  delay 
+    $> sub-input-buffer{_, input}
+    $> sub-output-buffer{_, output}
+
+
+;==============================================================================
+;============================ Input Data ======================================
+;==============================================================================
+public defstruct Node : 
+  node-id:Int
+  inputs:Tuple<Port>
+  outputs:Tuple<Port>
+  latency:Double
+with : 
+  printer => true
+
+public defstruct Port : 
+  port-id:Int
+  type:Int
+with : 
+  printer => true
+
+public defstruct Edge : 
+  edge-id:Int
+  src-node:Int
+  src-port:Int
+  dst-node:Int
+  dst-port:Int
+with : 
+  printer => true
+
+;==============================================================================
+;================================= API ========================================
+;==============================================================================
+; Audio graph compiler driver
+;
+; Inputs: 
+; - num-port-types: The number of different port types we can expect.
+; - node-list:      A list of nodes in the graph, their ports, and latencies.
+; - edge-list:      A list of connections in the graph, from node.port to node.port.
+;
+; Output:
+; - CompiledSchdule with : 
+;   - order: topological order to evaluate nodes, delays, and summing points
+;   - inserted-delays: list of (possibly) updated 
+public defn compile (num-port-types:Int, 
+                     node-list:Tuple<Node>, 
+                     edge-list:Tuple<Edge>) -> CompiledSchedule : 
+  preprocess(num-port-types, node-list, edge-list) ; First, collect input IR into GraphIR structure 
+    $> sort-topologically                          ; Next, sort the graph topologically to create initial order
+    $> solve-latency-requirements                  ; Iterate the order, solving for latency requirements and insert delays
+    $> solve-buffer-requirements                   ; Iterate the order with delays, solving for buffer requirements and insert sums
+    $> merge                                       ; Merge the resulting data from the passes into the Result
+
+;==============================================================================
+;============================== Internals =====================================
+;==============================================================================
+; An internal IR that holds the data needed for the compiler passes.
+public defstruct GraphIR : 
+  nodes:IntTable<Node> ; table of nodes in the graph
+  edges:IntTable<Edge> ; table of edges in the graph
+  adjacent:IntTable<Vector<Edge>> ; table of adjacent edges to nodes
+  allocator:BufferAllocator       ; a buffer allocator object, initially empty
+  assigned-buffers:IntTable<BufferRef> with : ; a table of buffers assigned ot edges, initially empty
+    default => IntTable<BufferRef>()
+  node-order:Tuple<Node|ScheduleEntry> with : ; the topological order of the graph, initially empty
+    updater => sub-node-order
+    default => []
+
+; Returns adjacent nodes along outgoing edges from a node
+defn outgoing (g:GraphIR, node:Node) -> Seq<Node> : 
+  val edges = adjacent(g)[node-id(node)]
+  for edge in edges seq? : 
+    if src-node(edge) == node-id(node) :  
+      One(nodes(g)[dst-node(edge)])
+    else : 
+      None()
+
+; Returns adjacent nodes along incoming edges to a node
+defn incoming (g:GraphIR, node:Node) -> Seq<Node> : 
+  val edges = adjacent(g)[node-id(node)]
+  for edge in edges seq? : 
+    if dst-node(edge) == node-id(node) :  
+      One(nodes(g)[dst-node(edge)])
+    else : 
+      None()
+
+; Returns nodes with indegree 0, the roots of the graph
+defn roots  (g:GraphIR) -> Seq<Node> :
+  for node in values(nodes(g)) filter : 
+    empty?(incoming(g, node))
+
+public defstruct BufferRef : 
+  id:Int
+  type-id:Int
+  ref-count:Int with : 
+    default => 1
+    setter  => set-ref-count
+with : 
+  printer => true
+defn inc (b:BufferRef) : set-ref-count(b, ref-count(b) + 1)
+defn dec (b:BufferRef) : set-ref-count(b, ref-count(b) - 1)
+defn clone (b:BufferRef) -> BufferRef : 
+  inc(b)
+  b
+
+public deftype BufferAllocator 
+defmulti acquire (alloc:BufferAllocator, type-id:Int) -> BufferRef 
+defmulti release (alloc:BufferAllocator, ref:BufferRef) -> False
+defmulti max-num-buffers (alloc:BufferAllocator) -> Tuple<[Int, Int]>
+
+defn BufferAllocator (num-types:Int) : 
+  val free-lists = to-tuple(seq(Vector<Int>{}, 0 to num-types))
+  val counts     = to-array<Int>(seq({0}, 0 to num-types))
+
+  new BufferAllocator : 
+    defmethod print (o:OutputStream, this) : 
+      print(o, "BufferAllocator state:")
+      val oo = IndentedStream(o)
+      lnprint(oo, "- free-lists: %," % [free-lists])
+      lnprint(oo, "- counts: %," % [counts])
+
+    defmethod acquire (this, type-id:Int) : 
+      if empty?(free-lists[type-id]) : 
+        val id = counts[type-id] + 1
+        counts[type-id] = id
+        BufferRef(id, type-id)
+      else : 
+        val id = pop(free-lists[type-id])
+        BufferRef(id, type-id)
+    defmethod release (this, ref:BufferRef) : 
+      dec(ref)
+      if ref-count(ref) == 0 : 
+        add(free-lists[type-id(ref)], id(ref))
+    defmethod max-num-buffers (this) : 
+      to-tuple $ 
+        for (count in counts, type in 0 to num-types) seq : 
+          [type, count + 1]
+
+;==============================================================================
+;=============================== Passes =======================================
+;==============================================================================
+; "Preprocess" the input to the compiler, initializing the GraphIR
+defn preprocess (num-port-types:Int, node-list:Tuple<Node>, edge-list:Tuple<Edge>) -> GraphIR : 
+  GraphIR(nodes, edges, adjacent, allocator) where : 
+    val nodes     = to-inttable<Node>(seq({node-id(_0) => _0}, node-list))
+    val edges     = to-inttable<Edge>(seq({edge-id(_0) => _0}, edge-list))
+    val adjacent  = IntTable-init<Vector<Edge>>({Vector<Edge>()})
+    val allocator = BufferAllocator(num-port-types)
+    for edge in values(edges) do : 
+      add(adjacent[src-node(edge)], edge)
+      add(adjacent[dst-node(edge)], edge)
+
+; DFS walk of the graph to initialize the node-order, sorting the graph 
+; topologically. Fails if there are cycles in the input.
+defn sort-topologically (g:GraphIR) -> GraphIR :
+  ; First, we check for cycles in the graph.
+  defn cycle-check (node:Node) :
+    ; blah blah blah, do it efficiently via Tarjan's algorithm or something
+    defn visit (node:Node, check:Node) : 
+      fatal("Cycle detected") when node-id(node) == node-id(check)
+      do(visit{_, check}, outgoing(g, node))
+    do(visit{_, node}, outgoing(g, node))
+  do(cycle-check, roots(g))
+
+  val node-order = Vector<Node>()
+  val visited    = HashSet<Int>()
+  val queue      = Queue<Node>()
+  do(add{queue, _}, roots(g))
+  
+  let loop () : 
+    if not empty?(queue) : 
+      val node = pop(queue) 
+      if not visited[node-id(node)] :
+        add(visited, node-id(node))
+        do(add{queue, _}, outgoing(g, node))
+        add(node-order, node)
+      loop()
+  val node-order* = to-tuple(node-order)
+  sub-node-order(g, node-order*)
+
+; Solves the latency requirements of the graph, by computing how 
+; much delay is required at edges and then inserting delays into
+; the node-order.
+;
+defn solve-latency-requirements (g:GraphIR) -> GraphIR : 
+  sub-node-order(g, order) where : 
+    val time-of-arrival = HashTable<Int, Double>()
+    val order = to-tuple $ 
+      for entry in node-order(g) seq-cat :
+        val node = entry as Node 
+        val incoming-edges  = filter({dst-node(_) == node-id(node)}, adjacent(g)[node-id(node)])
+        val input-latencies = to-tuple $ 
+          for incoming-edge in incoming-edges seq : 
+            incoming-edge => time-of-arrival[src-node(incoming-edge)]
+        val max-input-latency = maximum(seq(value, input-latencies)) when not empty?(input-latencies) else 0.0
+        val delays = 
+          for kv in input-latencies seq? : 
+            val delay = max-input-latency - value(kv)
+            if delay != 0.0 : One $
+              InsertedDelay(edge, delay) where : 
+                val edge = key(kv)
+                val delay   = max-input-latency - value(kv)
+            else : 
+              None()
+        time-of-arrival[node-id(node)] = max-input-latency + latency(node)
+        cat-all([delays, [node]])
+
+defn solve-buffer-requirements (g:GraphIR) -> GraphIR : 
+  sub-node-order(g, order) where : 
+    val order = to-tuple $ 
+    for entry in node-order(g) seq-cat : 
+      match(entry) : 
+        (node:Node) : 
+          val [scheduled-node, sums] = assign-buffers(g, node)
+          cat-all([sums, [scheduled-node]])
+        (delay:InsertedDelay) : 
+          [assign-buffers(g, delay)]
+
+defn merge (g:GraphIR) -> CompiledSchedule : 
+  CompiledSchedule(order, delays, num-buffers) where : 
+    val order  = map({_ as ScheduleEntry} node-order(g))
+    val delays = to-tuple(filter-by<InsertedDelay>(order))
+    val num-buffers = max-num-buffers(allocator(g))
+  
+; Buffer assignment for a single node in the graph.
+; 
+; Input : 
+;   - A node to assign i/o buffers
+;   - A list of edges connected to the node
+; State : 
+;   - A list of allocator stacks, one for each type of port in the node
+;   - A table of (edge-id) => (buffer-id). 
+; Output : 
+;   - A list of buffers that have been assigned to the node
+;   - A list of summation/merge points to add to the schedule
+;
+; Behavior : 
+;   - Every input and output port has exactly one buffer assigned to it
+;   - Output ports connected to an edge share the same buffer as that edge
+;   - If an input port has exactly one incoming edge, it shares a buffer 
+;     with the incoming edge (and therefore, the output port of the edge)
+;   - If an input port is connected to multiple edges, a sum/merge point
+;     is created and returned. This point has a list of buffers to merge,
+;     and an output buffer that is shared with the corresponding input port.
+;   - A best-effort is given to minimize the number of buffers needed
+defn assign-buffers (g:GraphIR, node:Node) -> [ScheduledNode, Seqable<InsertedSum>] :
+  [scheduled-node, summing-nodes] where : 
+    val edges = adjacent(g)[node-id(node)]
+
+    ; Collections to hold the output that is constructed incrementally
+    val summing-nodes  = Vector<InsertedSum>()
+    val input-buffers  = Vector<BufferAssignment>()
+    val output-buffers = Vector<BufferAssignment>()
+
+    ; First, collect the input/output ports.
+    ;
+    ; Order matters! Outputs should be traversed before inputs in order
+    ; to minimize the number of buffers allocated.
+    val io = cat-all([
+      seq({[_, false]}, outputs(node))
+      seq({[_, true]},  inputs(node)), 
+    ])
+
+    ; Iterate the list of ports
+    for [port, is-input?] in io do : 
+      val port-id = port-id(port)
+      val type    = type(port)
+      val edges*  = to-tuple $ 
+        for edge in edges filter :
+          contains?([dst-port(edge), src-port(edge)], port-id) 
+      val buffer-assignments = input-buffers when is-input? else output-buffers
+      
+      ; Case 1: The port is unconnected. Acquire a buffer, and immediately release it.
+      if empty?(edges*) : 
+        add(buffer-assignments, BufferAssignment(buffer-id, port-id, should-clear?, type)) where : 
+          val buffer        = acquire(allocator(g), type)
+          val should-clear? = true
+          val buffer-id     = id(buffer)
+          release(allocator(g), buffer)
+      
+      ; Case 2: The port is an input, and has exactly one incoming edge. Lookup the corresponding
+      ;         buffer, and release it.
+      else if length(edges*) == 1 and is-input? : 
+        add(buffer-assignments, BufferAssignment(buffer-id, port-id, should-clear?, type)) where : 
+          val buffer        = assigned-buffers(g)[edge-id(edges*[0])]
+          val buffer-id     = id(buffer)
+          val should-clear? = false
+          release(allocator(g), buffer)
+      
+      ; Case 3: The port is an output. Acquire a buffer, and add to the assignment table with 
+      ;         any corresponding edge ids.
+      else if not is-input? :
+        add(buffer-assignments, BufferAssignment(buffer-id, port-id, should-clear?, type)) where : 
+          val buffer        = acquire(allocator(g), type)
+          val should-clear? = true
+          val buffer-id     = id(buffer)
+          dec(buffer)
+          for edge in edges* do : 
+            assigned-buffers(g)[edge-id(edge)] = clone(buffer)
+
+      ; Case 4: The port is an input with multiple incoming edges. Compute the summing point 
+      ;         and map the input buffer assignment to the output of the summing point.
+      else : 
+        val sum-output    = acquire(allocator(g), type)
+        val sum-inputs    = map(get{assigned-buffers(g), edge-id(_)}, edges*)
+        val summing-point = InsertedSum(map(id, sum-inputs), id(sum-output))
+
+        add(summing-nodes, summing-point)
+        add(buffer-assignments, BufferAssignment(buffer-id, port-id, should-clear?, type)) where : 
+          val buffer-id     = id(sum-output)
+          val should-clear? = false
+          release(allocator(g), sum-output)
+
+    val scheduled-node = ScheduledNode(node-id(node), to-tuple(input-buffers), to-tuple(output-buffers), latency(node))
+
+defn assign-buffers (graph:GraphIR, 
+                     delay:InsertedDelay) -> InsertedDelay :
+  sub-buffers(delay, input-buffer, output-buffer) where : 
+    val edge = edges(graph)[edge-id(delay)]
+    val node = nodes(graph)[dst-node(edge)]
+    val type = type(find!({port-id(_) == dst-port(edge)}, inputs(node)))
+    val input-buffer-ref  = assigned-buffers(graph)[edge-id(delay)]
+    val output-buffer-ref = acquire(allocator(graph), type)
+    assigned-buffers(graph)[edge-id(delay)] = output-buffer-ref
+    release(allocator(graph), output-buffer-ref)
+    release(allocator(graph), input-buffer-ref)
+    val input-buffer  = id(input-buffer-ref)
+    val output-buffer = id(output-buffer-ref)

--- a/prototype/stanza.proj
+++ b/prototype/stanza.proj
@@ -1,0 +1,3 @@
+package audio-graph/main defined-in "main.stanza"
+package audio-graph/tests defined-in "tests.stanza"
+package audio-graph/graphviz defined-in "graphviz.stanza"

--- a/prototype/tests.stanza
+++ b/prototype/tests.stanza
@@ -1,0 +1,202 @@
+#use-added-syntax(tests)
+defpackage audio-graph/tests : 
+  import core
+  import collections
+  import audio-graph/graphviz
+  import audio-graph/main
+
+val AUDIO : Int = 0
+val EVENT : Int = 1
+
+deftest simple-parallel-graph : 
+  ; 1 ----> 2 -----*--> 4
+  ;   \           /
+  ;    * -> 3 - *
+  ;
+  val nodes = [
+    Node(2, [Port(21, AUDIO)], 
+            [Port(22, AUDIO)], 0.0)
+    Node(1, [], 
+            [Port(10, AUDIO)], 0.0)
+    Node(4, [Port(41, AUDIO)], 
+            [],                0.0)
+    Node(3, [Port(31, AUDIO)], 
+            [Port(32, AUDIO)], 0.0)
+  ]
+  
+  val edges = [
+    Edge(101, 1, 10, 3, 31)
+    Edge(103, 3, 32, 4, 41)
+    Edge(102, 2, 22, 4, 41)
+    Edge(100, 1, 10, 2, 21)
+  ]
+
+  print-graphviz(nodes, edges)
+  
+
+  val num-port-types = 1
+  val result = compile(1, nodes, edges)
+
+  #EXPECT(schedule(result)[0] is ScheduledNode)
+  #EXPECT(schedule(result)[1] is ScheduledNode)
+  #EXPECT(schedule(result)[2] is ScheduledNode)
+  #EXPECT(schedule(result)[3] is InsertedSum)
+  #EXPECT(schedule(result)[4] is ScheduledNode)
+  #EXPECT(num-buffers(result)[0] == [0, 4])
+
+  val e0 = schedule(result)[0] as ScheduledNode
+  val e1 = schedule(result)[1] as ScheduledNode
+  val e2 = schedule(result)[2] as ScheduledNode
+  val e3 = schedule(result)[3] as InsertedSum
+  val e4 = schedule(result)[4] as ScheduledNode
+
+  #EXPECT(empty?(input-buffers(e0)))
+  #EXPECT(buffer-id(input-buffers(e1)[0])  == buffer-id(input-buffers(e2)[0]))
+  #EXPECT(buffer-id(output-buffers(e1)[0]) != buffer-id(output-buffers(e2)[0]))
+  #EXPECT(buffer-id(input-buffers(e4)[0])  == buffer-id(output-buffers(e0)[0]))
+
+deftest parallel-buffer-allocation : 
+  ;             *-----> 2
+  ;            /       
+  ;   1 ------*         
+  ;            \
+  ;             * ----> 3          
+  ;            /
+  ;   4 ------*
+  ;            \      
+  ;             *-----> 5
+
+
+  val nodes = [
+    Node(1, [], 
+            [Port(11, AUDIO)], 0.0)
+    Node(2, [Port(21, AUDIO)], 
+            [], 0.0)
+    Node(3, [Port(31, AUDIO)], 
+            [], 0.0)
+    Node(4, [], 
+            [Port(41, AUDIO)], 0.0)
+    Node(5, [Port(51, AUDIO)], 
+            [],                0.0)
+  ]
+
+  val edges = [
+    Edge(100, 1, 11, 2, 21)
+    Edge(101, 1, 11, 3, 31)
+    Edge(102, 4, 41, 3, 31)
+    Edge(103, 4, 41, 5, 51)
+  ]
+  print-graphviz(nodes, edges)
+  
+  val result   = compile(1, nodes, edges)
+  val schedule = filter-by<ScheduledNode>(schedule(result))
+  val entries  = filter(contains?{[2 3 5], node-id(_)} schedule)
+  val inputs   = to-tuple $ seq-cat(input-buffers, entries)
+  val outputs  = to-tuple $ seq-cat(output-buffers, entries)
+
+  for input in inputs do : 
+    #EXPECT(not any?({buffer-id(_) == buffer-id(input)}, outputs))
+
+deftest unconnected-ports : 
+  val nodes = [ 
+    Node(1, [], [Port(11, AUDIO)], 0.0)
+    Node(2, [Port(21, AUDIO), Port(22, AUDIO)], [Port(23, AUDIO)], 0.0)
+  ]
+
+  val edges = [Edge(100, 1, 11, 2, 21)]
+  print-graphviz(nodes, edges)
+
+  val schedule = schedule(compile(1, nodes, edges))
+  #EXPECT(length(schedule) == 2)
+  val e1 = schedule[0]
+  val e2 = schedule[1]
+  
+  for entry in schedule do : 
+    match(entry:ScheduledNode) : 
+      val node    = find!({node-id(_) == node-id(entry)}, nodes)
+      val buffers = cat-all([input-buffers(entry), output-buffers(entry)])
+      val ports   = cat-all([inputs(node), outputs(node)])
+      for port in ports do : 
+        val buffer = find({port-id(_) == port-id(port)}, buffers)
+        #EXPECT(buffer is-not False)
+
+
+deftest delay-compensation : 
+  defn random-latency () :
+    to-double(rand(20)) - 10.0
+  
+  ;             *-----> 3 ----*
+  ;            /               \                     
+  ;   1 ------*                 *----> 6 ----*       
+  ;            \               /              \      
+  ;             * ----> 4 ----*                \     
+  ;            /                                *----> 7
+  ;   2 ------*                                /
+  ;            \                              /
+  ;             *-----> 5 -------------------*
+  val nodes = [
+    Node(1, [], [Port(11, AUDIO)], random-latency())
+    Node(2, [], [Port(21, AUDIO)], random-latency())
+    Node(3, [Port(31, AUDIO)], [Port(32, AUDIO)], random-latency())
+    Node(4, [Port(41, AUDIO)], [Port(42, AUDIO)], random-latency())
+    Node(5, [Port(51, AUDIO)], [Port(52, AUDIO)], random-latency())
+    Node(6, [Port(61, AUDIO)], [Port(62, AUDIO)], random-latency())
+    Node(7, [Port(71, AUDIO)], [], 0.0)
+  ]
+
+  val edges = [
+    Edge(100, 1, 11, 3, 31)
+    Edge(101, 1, 11, 4, 41)
+    Edge(102, 2, 21, 4, 41)
+    Edge(103, 2, 21, 5, 51)
+    Edge(104, 3, 32, 6, 61)
+    Edge(106, 4, 42, 6, 61)
+    Edge(107, 5, 52, 7, 71)
+    Edge(108, 6, 62, 7, 71)
+  ]
+
+  print-graphviz(nodes, edges)
+  val result  = compile(1, nodes, edges)
+  val num-buffers = num-buffers(result)[0][1]
+  
+  ; Instead of real data we're going to accumulate 
+  ; the delay passing through the network from input
+  ; to output 
+  val buffers = Array<Double>(num-buffers)
+  for n in 0 to num-buffers do : 
+    buffers[n] = 0.0
+  
+  ; Simulate the latency of the nodes and compensation
+  ; applied to them
+  for entry in schedule(result) do : 
+    match(entry) : 
+      (node:ScheduledNode) :
+        if length(input-buffers(node)) == length(output-buffers(node)) :
+          for (inpt in input-buffers(node), outp in output-buffers(node)) do : 
+            val acc = buffers[buffer-id $ inpt] + latency(node)
+            buffers[buffer-id $ outp] = acc
+        else : 
+          for outp in output-buffers(node) do : 
+            buffers[buffer-id $ outp] = latency(node)
+      (delay:InsertedDelay) : 
+        val acc = buffers[input-buffer(delay) as Int] + /delay(delay)
+        buffers[output-buffer(delay) as Int] = acc
+      (sum:InsertedSum) : 
+        ; Important check: summation nodes require all inputs to be in
+        ; phase. Here we check that the buffers at merge points are all
+        ; sync'd. 
+        #EXPECT(all-equal?(seq({buffers[_]}, input-buffers(sum))))
+        buffers[output-buffer(sum)] = buffers[input-buffers(sum)[0]]
+  
+  ; The last node evaluted is our sink, and it should also have the longest
+  ; delay time attached to it.
+  val sink = schedule(result)[length(schedule(result)) - 1] as ScheduledNode
+  #EXPECT(buffers[buffer-id $ input-buffers(sink)[0]] == maximum(buffers))
+
+defn all-equal? (s:Seqable<Equalable>) : 
+  val s* = to-seq(s)
+  if empty?(s*) : true
+  else : 
+    val v = next(s*)
+    all?({_ == v}, s*)
+  

--- a/readme.md
+++ b/readme.md
@@ -33,8 +33,7 @@ graph.connect(port2, out_port)?;
 // set input_1 to have a delay of 2 samples
 graph.set_delay(input_1, 2)?;
 
-let schedule = graph.compile(&mut schedule);
-for entry in schedule.scheduled {
+for entry in graph.compile() {
     let node_name = entry.node;
 
     // inputs may have multiple buffers to handle, in which case the

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,6 @@ Work in progress audio graph implementation
 use audio_graph::*;
 
 let mut graph = Graph::default();
-let mut schedule = Schedule::default();
 
 let input1 = graph.node("Input 1");
 let input2 = graph.node("Input 2");
@@ -34,16 +33,14 @@ graph.connect(port2, out_port)?;
 // set input_1 to have a delay of 2 samples
 graph.set_delay(input_1, 2)?;
 
-graph.compile(&mut schedule);
-for entry in schedule {
-    let node_name = graph.node_ident(entry.node)?;
+let schedule = graph.compile(&mut schedule);
+for entry in schedule.scheduled {
+    let node_name = entry.node;
 
     // inputs may have multiple buffers to handle, in which case the
     // buffers will need to be mixed together into a single buffer
     // before being sent to the node
-    for (port, buffers) in entry.inputs {
-        let port_name = graph.port_ident(entry.node)?;
-
+    for (port_name, buffers) in entry.inputs {
         for (buf, delay_comp) in buffers {
             // id (index) of the buffer
             let buffer_id = buf.buffer_id;
@@ -59,9 +56,7 @@ for entry in schedule {
         }
     }
     // outputs have exactly one buffer they write to
-    for (port, buf) in entry.outputs {
-        let port_name = graph.port_ident(entry.node)?;
-
+    for (port_name, buf) in entry.outputs {
         // id (index) of the buffer
         let buffer_id = buf.buffer_id;
 

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,6 @@ for entry in graph.compile() {
 ## Constraints:
 
 - Ports are typed, and only ports of the same type can be connected. By default there is the `DefaultPortType` enum which has `Audio` and `Event`, but you may define your own types if you wish.
-- Ports can be bidirectional. This is a quirk of the current implementation, but don't rely on it.
+- Ports are unidirectional.
 - Cycles are not supported, and an error will be returned if tried.
 - Multithreaded schedules are not yet implemented.

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,8 @@ Work in progress audio graph implementation
 use audio_graph::*;
 
 let mut graph = Graph::default();
+let mut schedule = Schedule::default();
+
 let input1 = graph.node("Input 1");
 let input2 = graph.node("Input 2");
 let output = graph.node("Output");
@@ -32,29 +34,36 @@ graph.connect(port2, out_port)?;
 // set input_1 to have a delay of 2 samples
 graph.set_delay(input_1, 2)?;
 
-let schedule = graph.compile();
+graph.compile(&mut schedule);
 for entry in schedule {
-    let node_name = entry.node;
+    let node_name = graph.node_ident(entry.node)?;
+
     // inputs may have multiple buffers to handle, in which case the
     // buffers will need to be mixed together into a single buffer
     // before being sent to the node
-    for (port_name, buffers) in entry.inputs {
-        for (buf, delay_comp) in buffers {
-            // index of the buffer
-            let index = b.index;
+    for (port, buffers) in entry.inputs {
+        let port_name = graph.port_ident(entry.node)?;
 
-            // delay compensation that needs to be applied to the
-            // contents of this buffer before being mixed & sent to
-            // the node
-            let delay_comp = *delay_comp;
+        for (buf, delay_comp) in buffers {
+            // id (index) of the buffer
+            let buffer_id = buf.buffer_id;
+
+            if let Some(delay_comp) = delay_comp {
+                // delay compensation that needs to be applied to the
+                // contents of this buffer before being mixed & sent to
+                // the node
+                let delay = delay_comp.delay;
+            }
 
             // ... 
         }
     }
     // outputs have exactly one buffer they write to
-    for (port_name, buf) in entry.outputs {
-        // index of the buffer
-        let index = b.index;
+    for (port, buf) in entry.outputs {
+        let port_name = graph.port_ident(entry.node)?;
+
+        // id (index) of the buffer
+        let buffer_id = buf.buffer_id;
 
         // ... 
     }

--- a/src/buffer_allocator2.rs
+++ b/src/buffer_allocator2.rs
@@ -1,0 +1,106 @@
+///! Buffer allocation internals v2.
+///!
+///! The [BufferAllocator] is implemented using a list of
+///! stacks, with one stack for each port type. When a
+///! new buffer is required, we first try and pop a buffer
+///! off the stack. If it none are available, we allocate
+///! a new buffer. When a buffer is released, it is
+///! pushed to the top of the corresponding stack.
+///!
+///! There is some additional bookkeeping required for the
+///! buffers. [BufferRef]s contain a `ref_count` field which
+///! tracks the number of edges that still need the buffer
+///! to be alive before it can be safely released. The
+///! `generation` field is kept around for visualization
+///! of the assigned buffers during debugging.
+///!
+///! Finally, the engine using the graph needs to know
+///! the maximum number of buffers for each port type
+///! to allocate during its prepare for playback operation.
+///! We track this by counting each time a new buffer
+///! is allocated for a type in the `counts` list.
+///!
+///! Since it is not valid for the buffer allocator to
+///! keep allocating after the `counts` field has been
+///! consumed, we require consuming `self` to retrieve it.
+use serde::{Deserialize, Serialize};
+use std::rc::Rc;
+
+/// A reference to an abstract buffer during buffer allocation.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct BufferRef {
+    /// The index of the buffer
+    pub idx: usize,
+    /// The type index of the buffer
+    pub type_idx: usize,
+    /// The generation, or the nth time this buffer has
+    /// been assigned to a different edge in the graph.
+    pub generation: usize,
+}
+
+impl BufferRef {
+    /// Create a new BufferRef
+    pub fn new(idx: usize, type_idx: usize, generation: usize) -> Self {
+        Self {
+            idx,
+            type_idx,
+            generation,
+        }
+    }
+}
+
+/// An allocator for managing and reusing [BufferRef]s.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BufferAllocator {
+    /// A list of free buffers that may be reallocated, one list for
+    /// each different port type.
+    pub free_lists: Vec<Vec<FreeListEntry>>,
+    /// A list of the maximum number of buffers used for each port type.
+    pub counts: Vec<usize>,
+}
+
+/// A small helper struct for tracking the index and generation
+/// of data in the free lists
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FreeListEntry {
+    pub idx: usize,
+    pub generation: usize,
+}
+
+impl BufferAllocator {
+    /// Create a new allocator, `num_types` defines the number
+    /// of buffer types we may allocate.
+    pub fn new(num_types: usize) -> BufferAllocator {
+        Self {
+            free_lists: vec![vec![]; num_types],
+            counts: vec![0; num_types],
+        }
+    }
+
+    /// Acquire a new buffer with a given type index. Panics if
+    /// the type index is out of bounds.
+    pub fn acquire(&mut self, type_idx: usize) -> Rc<BufferRef> {
+        let entry = self.free_lists[type_idx].pop().unwrap_or_else(|| {
+            let idx = self.counts[type_idx] + 1;
+            self.counts[type_idx] = idx;
+            FreeListEntry { idx, generation: 0 }
+        });
+        Rc::new(BufferRef::new(entry.idx, type_idx, entry.generation))
+    }
+
+    /// Release a BufferRef.
+    pub fn release(&mut self, buffer_ref: Rc<BufferRef>) {
+        if Rc::strong_count(&buffer_ref) == 1 {
+            self.free_lists[buffer_ref.type_idx].push(FreeListEntry {
+                idx: buffer_ref.idx,
+                generation: buffer_ref.generation + 1,
+            });
+        }
+    }
+
+    /// Consume the allocator to return the maximum number of buffers used
+    /// for each type.
+    pub fn num_buffers_per_type(self) -> Vec<usize> {
+        self.counts
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,13 +1,12 @@
 use crate::buffer_allocator::{Buffer, BufferAllocator};
 use crate::graph::{NodeRef, PortRef};
 use crate::port_type::PortType;
-use crate::scheduled::ScheduledNode;
 use crate::vec::Vec;
 use fnv::{FnvHashMap, FnvHashSet};
 use std::collections::VecDeque;
 
 #[derive(Debug)]
-pub(crate) struct HeapStore<N, P, PT>
+pub(crate) struct HeapStore<PT>
 where
     PT: PortType,
 {
@@ -19,16 +18,14 @@ where
     pub deps: Vec<NodeRef>,
     pub allocator: BufferAllocator<PT>,
     pub delay_comps: Option<FnvHashMap<(PortRef, PortRef), u64>>,
-    pub input_assignments: FnvHashMap<(NodeRef, PortRef), Vec<(Buffer<PT>, (PortRef, PortRef))>>,
+    pub input_assignments:
+        FnvHashMap<(NodeRef, PortRef), Vec<(Buffer<PT>, PortRef, PortRef, NodeRef)>>,
     pub output_assignments: FnvHashMap<(NodeRef, PortRef), (Buffer<PT>, usize)>,
     pub scheduled_nodes: Option<Vec<NodeRef>>,
-    pub scheduled: Option<Vec<ScheduledNode<N, P, PT>>>,
 }
 
-impl<N, P, PT> Default for HeapStore<N, P, PT>
+impl<PT> Default for HeapStore<PT>
 where
-    N: Clone,
-    P: Clone,
     PT: PortType,
 {
     fn default() -> Self {
@@ -44,7 +41,6 @@ where
             input_assignments: FnvHashMap::default(),
             output_assignments: FnvHashMap::default(),
             scheduled_nodes: Some(Vec::new()),
-            scheduled: None,
         }
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,12 +1,13 @@
 use crate::buffer_allocator::{Buffer, BufferAllocator};
 use crate::graph::{NodeRef, PortRef};
 use crate::port_type::PortType;
+use crate::scheduled::ScheduledNode;
 use crate::vec::Vec;
 use fnv::{FnvHashMap, FnvHashSet};
 use std::collections::VecDeque;
 
 #[derive(Debug)]
-pub(crate) struct HeapStore<PT>
+pub(crate) struct HeapStore<N, P, PT>
 where
     PT: PortType,
 {
@@ -22,10 +23,16 @@ where
         FnvHashMap<(NodeRef, PortRef), Vec<(Buffer<PT>, PortRef, PortRef, NodeRef)>>,
     pub output_assignments: FnvHashMap<(NodeRef, PortRef), (Buffer<PT>, usize)>,
     pub scheduled_nodes: Option<Vec<NodeRef>>,
+
+    // Note, we are using a std Vec instead of a SmallVec because the latter was
+    // causing stack overflows.
+    pub scheduled: Option<std::vec::Vec<ScheduledNode<N, P, PT>>>,
 }
 
-impl<PT> Default for HeapStore<PT>
+impl<N, P, PT> Default for HeapStore<N, P, PT>
 where
+    N: Clone,
+    P: Clone,
     PT: PortType,
 {
     fn default() -> Self {
@@ -41,6 +48,7 @@ where
             input_assignments: FnvHashMap::default(),
             output_assignments: FnvHashMap::default(),
             scheduled_nodes: Some(Vec::new()),
+            scheduled: None,
         }
     }
 }

--- a/src/graph_ir.rs
+++ b/src/graph_ir.rs
@@ -1,0 +1,375 @@
+//! The internal [GraphIR] datastructure used by the compiler passes.
+//!
+use crate::{input_ir::*, output_ir::*};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+/// Internal IR used by the compiler algorithm. Built incrementally
+/// via the compiler passes.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GraphIR {
+    /// The number of port types used by the graph.
+    pub num_port_types: usize,
+    /// A table of nodes in the graph.
+    pub nodes: HashMap<u64, Node>,
+    /// A list of edges in the graph.
+    pub edges: HashMap<u64, Edge>,
+    /// Adjacency list table. Built internally.
+    pub adjacent: HashMap<u64, Vec<Edge>>,
+    /// The topologically sorted schedule of the graph. Built internally.
+    pub schedule: Vec<TempEntry>,
+    /// The maximum number of buffers used for each port type. Built internally.
+    pub max_num_buffers: Vec<usize>,
+}
+
+/// An entry in the schedule order. Since it is built incrementally, it
+/// is not equivalent to a [ScheduledNode].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum TempEntry {
+    /// A node in the order that has not been completely scheduled yet.
+    Node(Node),
+    /// A completely scheduled node
+    ScheduledNode(ScheduledNode),
+    /// An inserted delay into the the order
+    Delay(TempDelay),
+    /// An inserted sum point into the order
+    Sum(InsertedSum),
+}
+
+/// A delay that has been inserted into the order but has
+/// not yet been assigned i/o buffers.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct TempDelay {
+    /// The edge that this delay corresponds to. Kept for debugging and visualization.
+    pub edge: Edge,
+    /// The amount of delay to apply to the input.
+    pub delay: f64,
+    /// The input data to read.
+    pub input_buffer: Option<BufferAssignment>,
+    /// The output buffer to write delayed into to.
+    pub output_buffer: Option<BufferAssignment>,
+}
+
+/// Main compilation algorithm
+pub fn compile(
+    num_port_types: usize,
+    nodes: impl IntoIterator<Item = Node>,
+    edges: impl IntoIterator<Item = Edge>,
+) -> CompiledSchedule {
+    GraphIR::preprocess(num_port_types, nodes, edges)
+        .sort_topologically()
+        .solve_latency_requirements()
+        .solve_buffer_requirements()
+        .merge()
+}
+
+impl GraphIR {
+    /// Construct a [GraphIR] instance from lists of nodes and edges, building
+    /// up the adjacency table and creating an empty schedule.
+    pub fn preprocess(
+        num_port_types: usize,
+        nodes: impl IntoIterator<Item = Node>,
+        edges: impl IntoIterator<Item = Edge>,
+    ) -> Self {
+        let nodes = nodes.into_iter().map(|n| (n.id, n)).collect();
+        let edges: HashMap<u64, Edge> = edges.into_iter().map(|e| (e.id, e)).collect();
+        let mut adjacent = HashMap::new();
+        for edge in edges.values() {
+            let src = adjacent.entry(edge.src_node).or_insert_with(Vec::new);
+            src.push(*edge);
+            let dst = adjacent.entry(edge.dst_node).or_insert_with(Vec::new);
+            dst.push(*edge);
+        }
+        Self {
+            num_port_types,
+            nodes,
+            edges,
+            adjacent,
+            schedule: vec![],
+            max_num_buffers: vec![],
+        }
+    }
+
+    /// Walk the nodes of the graph and add them to the schedule.
+    pub fn sort_topologically(mut self) -> Self {
+        debug_assert!(self.tarjan() == 0, "Graph contains cycles.");
+        let mut stack = self.roots().cloned().collect::<Vec<_>>();
+        let mut visited = HashSet::with_capacity(self.nodes.len());
+
+        self.schedule.clear();
+
+        while let Some(node) = stack.pop() {
+            if !visited.contains(&node.id) {
+                visited.insert(node.id);
+                for next in self.outgoing(&node) {
+                    stack.push(next.clone());
+                }
+                self.schedule.push(TempEntry::Node(node));
+            }
+        }
+
+        self
+    }
+
+    pub fn solve_latency_requirements(mut self) -> Self {
+        let mut time_of_arrival = HashMap::new();
+        let mut new_schedule = Vec::with_capacity(self.schedule.capacity());
+        for entry in self.schedule {
+            let entry = if let TempEntry::Node(n) = entry {
+                n
+            } else {
+                unreachable!()
+            };
+            let incoming_edges = self.adjacent[&entry.id]
+                .iter()
+                .filter(|edge| edge.dst_node == entry.id);
+            let input_latencies = incoming_edges
+                .map(|edge| {
+                    let node = edge.src_node;
+                    (edge, time_of_arrival[&node])
+                })
+                .collect::<Vec<_>>();
+            let max_input_latency = input_latencies
+                .iter()
+                .fold(f64::MIN, |acc, lhs| acc.max(lhs.1));
+            time_of_arrival.insert(entry.id, max_input_latency + entry.latency);
+            let delays = input_latencies.into_iter().filter_map(|(edge, delay)| {
+                if delay != 0.0 {
+                    let inserted = TempDelay {
+                        delay,
+                        edge: *edge,
+                        input_buffer: None,
+                        output_buffer: None,
+                    };
+                    Some(inserted)
+                } else {
+                    None
+                }
+            });
+            for delay in delays {
+                new_schedule.push(TempEntry::Delay(delay));
+            }
+            new_schedule.push(TempEntry::Node(entry));
+        }
+        self.schedule = new_schedule;
+        self
+    }
+
+    pub fn solve_buffer_requirements(mut self) -> Self {
+        let mut new_schedule = Vec::with_capacity(self.schedule.capacity());
+        for entry in &self.schedule {
+            match entry {
+                TempEntry::Node(node) => {
+                    let (scheduled, sums) = self.assign_node_buffers(node);
+                    for sum in sums {
+                        new_schedule.push(TempEntry::Sum(sum));
+                    }
+                    new_schedule.push(TempEntry::ScheduledNode(scheduled));
+                }
+                TempEntry::Delay(delay) => {
+                    let delay = self.assign_delay_buffers(*delay);
+                    new_schedule.push(TempEntry::Delay(delay));
+                }
+                _ => unreachable!(),
+            }
+        }
+        self.schedule = new_schedule;
+        self
+    }
+
+    #[allow(unreachable_code)]
+    pub fn assign_node_buffers(
+        &self,
+        _node: &Node,
+    ) -> (ScheduledNode, impl Iterator<Item = InsertedSum>) {
+        (todo!(), std::iter::from_fn(|| None))
+    }
+
+    pub fn assign_delay_buffers(&self, _delay: TempDelay) -> TempDelay {
+        todo!()
+    }
+
+    /// Merge the GraphIR into a [CompiledSchedule].
+    ///
+    /// Algorithm :
+    ///
+    /// For each temporary entry:
+    ///     - if entry is an unscheduled node, fail.
+    ///     - if entry is a delay
+    ///         - fail if buffers are unallocated
+    ///         - add delay to list of added delays, insert delay to schedule
+    ///     - if entry is a sum or scheduled node, add to schedule
+    ///
+    pub fn merge(self) -> CompiledSchedule {
+        debug_assert!(
+            self.max_num_buffers.len() == self.num_port_types,
+            "Missing buffer allocations in output."
+        );
+
+        let mut delays = vec![];
+        let mut schedule = vec![];
+
+        for entry in self.schedule {
+            let entry = match entry {
+                TempEntry::Node(_) => {
+                    debug_assert!(false, "Unscheduled node in output.");
+                    unreachable!();
+                }
+                TempEntry::Delay(delay) => {
+                    debug_assert!(
+                        delay.input_buffer.is_some(),
+                        "Unallocated input buffer in scheduled delay."
+                    );
+                    debug_assert!(
+                        delay.output_buffer.is_some(),
+                        "Unallocated output buffer in scheduled delay."
+                    );
+                    let delay = InsertedDelay {
+                        edge: delay.edge,
+                        delay: delay.delay,
+                        input_buffer: delay.input_buffer.unwrap(),
+                        output_buffer: delay.output_buffer.unwrap(),
+                    };
+                    delays.push(delay);
+                    ScheduleEntry::Delay(delay)
+                }
+                TempEntry::ScheduledNode(node) => ScheduleEntry::Node(node),
+                TempEntry::Sum(sum) => ScheduleEntry::Sum(sum),
+            };
+            schedule.push(entry);
+        }
+
+        CompiledSchedule {
+            schedule,
+            delays,
+            num_buffers: self.max_num_buffers,
+        }
+    }
+
+    /// List the adjacent nodes along outgoing edges of `n`.
+    pub fn outgoing<'a>(&'a self, n: &'a Node) -> impl Iterator<Item = &'a Node> + 'a {
+        self.adjacent[&n.id].iter().filter_map(move |e| {
+            if e.src_node == n.id {
+                Some(&self.nodes[&e.src_node])
+            } else {
+                None
+            }
+        })
+    }
+
+    /// List the adjacent nodes along incoming edges of `n`.
+    pub fn incoming<'a>(&'a self, n: &'a Node) -> impl Iterator<Item = &'a Node> + 'a {
+        self.adjacent[&n.id].iter().filter_map(move |e| {
+            if e.dst_node == n.id {
+                Some(&self.nodes[&e.src_node])
+            } else {
+                None
+            }
+        })
+    }
+
+    /// List root nodes, or nodes which have indegree of 0.
+    pub fn roots(&self) -> impl Iterator<Item = &Node> + '_ {
+        self.nodes
+            .values()
+            .filter(move |n| self.incoming(*n).next().is_none())
+    }
+
+    /// List the sink nodes, or nodes which have outdegree of 0.
+    pub fn sinks(&self) -> impl Iterator<Item = &Node> + '_ {
+        self.nodes
+            .values()
+            .filter(move |n| self.outgoing(*n).next().is_none())
+    }
+
+    /// Consume the GraphIR returning a new instance with an updated schedule.
+    pub fn with_schedule(mut self, i: impl IntoIterator<Item = TempEntry>) -> Self {
+        self.schedule = i.into_iter().collect();
+        self
+    }
+
+    /// Count the number of cycles in the graph using Tarjan's algorithm for
+    /// strongly connected components.
+    pub fn tarjan(&self) -> usize {
+        let mut index = 0;
+        let mut stack = Vec::with_capacity(self.nodes.len());
+        let mut aux: HashMap<u64, TarjanData> = self
+            .nodes
+            .iter()
+            .map(|(k, _)| (*k, TarjanData::default()))
+            .collect();
+
+        let mut num_cycles = 0;
+        fn strong_connect<'a>(
+            graph: &'a GraphIR,
+            aux: &mut HashMap<u64, TarjanData>,
+            node: &'a Node,
+            index: &mut u64,
+            stack: &mut Vec<&'a Node>,
+            outgoing: impl Iterator<Item = &'a Node> + 'a,
+            num_cycles: &mut usize,
+        ) {
+            aux.get_mut(&node.id).unwrap().index = Some(*index);
+            aux.get_mut(&node.id).unwrap().low_link = *index;
+            aux.get_mut(&node.id).unwrap().on_stack = true;
+            stack.push(node);
+            *index += 1;
+
+            for next in outgoing {
+                if aux[&next.id].index.is_none() {
+                    strong_connect(
+                        graph,
+                        aux,
+                        next,
+                        index,
+                        stack,
+                        graph.outgoing(next),
+                        num_cycles,
+                    );
+                    aux.get_mut(&node.id).unwrap().low_link =
+                        aux[&node.id].low_link.min(aux[&next.id].low_link);
+                } else if aux[&next.id].on_stack {
+                    aux.get_mut(&node.id).unwrap().low_link =
+                        aux[&node.id].low_link.min(aux[&next.id].index.unwrap());
+                }
+            }
+
+            if aux[&node.id].index.unwrap() == aux[&node.id].low_link {
+                let mut scc_count = 0;
+                loop {
+                    if let Some(scc) = stack.pop() {
+                        if scc.id == node.id {
+                            break;
+                        } else {
+                            scc_count += 1;
+                        }
+                    }
+                }
+                if scc_count != 0 {
+                    *num_cycles += 1;
+                }
+            }
+        }
+
+        for (_, node) in self.nodes.iter() {
+            strong_connect(
+                self,
+                &mut aux,
+                node,
+                &mut index,
+                &mut stack,
+                self.outgoing(node),
+                &mut num_cycles,
+            );
+        }
+
+        num_cycles
+    }
+}
+
+#[derive(Default)]
+struct TarjanData {
+    index: Option<u64>,
+    on_stack: bool,
+    low_link: u64,
+}

--- a/src/input_ir.rs
+++ b/src/input_ir.rs
@@ -35,7 +35,7 @@ pub struct Port {
     pub id: u64,
     /// A unique identifier for the type of data this port handles,
     /// for example nodes may have audio and event ports.
-    pub type_id: u64,
+    pub type_idx: usize,
 }
 
 /// An [Edge] is a connection from source node and port to a

--- a/src/input_ir.rs
+++ b/src/input_ir.rs
@@ -1,0 +1,56 @@
+//! Input data structures to the audio graph compiler.
+//!
+use serde::{Deserialize, Serialize};
+
+/// The input IR used by the audio graph compiler.  
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AudioGraphCompilerInput {
+    /// A list of nodes in the graph.
+    pub nodes: Vec<Node>,
+    /// A list of edges in the graph.
+    pub edges: Vec<Edge>,
+    /// The number of different port types used by the graph.
+    pub num_port_types: usize,
+}
+
+/// A [Node] is a single process in the audio network.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Node {
+    /// A globally unique identifier of the node.
+    pub id: u64,
+    /// A list of input ports used by the node
+    pub inputs: Vec<Port>,
+    /// A list of output ports used by the node.
+    pub outputs: Vec<Port>,
+    /// The latency this node adds to data flowing through it.
+    pub latency: f64,
+}
+
+/// A [Port] is a single point of input or output data
+/// for a node.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct Port {
+    /// A globally unique identifier of this port. Note: do not
+    /// mix IDs for ports with IDs for nodes and edges.
+    pub id: u64,
+    /// A unique identifier for the type of data this port handles,
+    /// for example nodes may have audio and event ports.
+    pub type_id: u64,
+}
+
+/// An [Edge] is a connection from source node and port to a
+/// destination node and port.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Edge {
+    /// A globally unique identifier for this connection. Note: do
+    /// not mix IDs for edges with IDs for nodes or ports.
+    pub id: u64,
+    /// The ID of the source node of this edge.
+    pub src_node: u64,
+    /// The ID of the source port used by this edge.
+    pub src_port: u64,
+    /// The ID of the destination of this edge.
+    pub dst_node: u64,
+    /// The ID of the destination port used by this edge.
+    pub dst_port: u64,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ mod graph;
 mod port_type;
 mod scheduled;
 mod vec;
+pub mod input_ir;
+pub mod output_ir;
 
 pub use error::Error;
 pub use graph::{Graph, NodeRef, PortRef};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod vec;
 pub use error::Error;
 pub use graph::{Graph, NodeRef, PortRef};
 pub use port_type::{DefaultPortType, PortType};
-pub use scheduled::{Schedule, ScheduledNode};
+pub use scheduled::ScheduledNode;
 
 #[cfg(test)]
 mod tests {
@@ -95,7 +95,7 @@ mod tests {
             .expect_err("Cycles should not be allowed");
 
         let mut last_node = None;
-        for entry in graph.compile().scheduled {
+        for entry in graph.compile() {
             println!("process {:?}:", entry.node);
             for (port, buffers) in entry.inputs.iter() {
                 println!("    {} => ", port);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ mod tests {
     #[test]
     fn simple_graph() {
         let mut graph = Graph::default();
-        let mut schedule = Schedule::default();
         let (a, b, c, d) = (
             graph.node("A"),
             graph.node("B"),
@@ -96,16 +95,12 @@ mod tests {
             .expect_err("Cycles should not be allowed");
 
         let mut last_node = None;
-        graph.compile(&mut schedule);
-        for entry in schedule.scheduled {
-            let node_id = graph.node_ident(entry.node).unwrap();
-            println!("process {:?}:", node_id);
-
+        for entry in graph.compile().scheduled {
+            println!("process {:?}:", entry.node);
             for (port, buffers) in entry.inputs.iter() {
-                let port_id = graph.port_ident(*port).unwrap();
-                println!("    {} => ", port_id);
+                println!("    {} => ", port);
 
-                if *port_id == "d_input_1" {
+                if *port == "d_input_1" {
                     for (b, delay_comp) in buffers {
                         println!("        index: {}", b.buffer_id);
                         println!("        delay_comp: {:?}", delay_comp);
@@ -122,7 +117,7 @@ mod tests {
                         println!("        delay_comp: {:?}", delay_comp);
 
                         let delay = delay_comp.as_ref().map(|d| d.delay).unwrap_or(0);
-                        if *port_id == "d_input_2" {
+                        if *port == "d_input_2" {
                             assert_eq!(delay, 3);
                         } else {
                             assert_eq!(delay, 0);
@@ -135,8 +130,6 @@ mod tests {
             }
             last_node = Some(entry.node.clone());
         }
-
-        let last_node_id = last_node.map(|n| *graph.node_ident(n).unwrap());
-        assert!(matches!(last_node_id, Some("D")));
+        assert!(matches!(last_node, Some("D")));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 mod buffer_allocator;
+mod buffer_allocator2;
 mod cache;
 mod error;
 mod graph;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
+#![allow(clippy::type_complexity)]
 mod buffer_allocator;
 mod cache;
 mod error;
 mod graph;
+pub mod graph_ir;
+pub mod input_ir;
+pub mod output_ir;
 mod port_type;
 mod scheduled;
 mod vec;
-pub mod input_ir;
-pub mod output_ir;
 
 pub use error::Error;
 pub use graph::{Graph, NodeRef, PortRef};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod vec;
 pub use error::Error;
 pub use graph::{Graph, NodeRef, PortRef};
 pub use port_type::{DefaultPortType, PortType};
-pub use scheduled::ScheduledNode;
+pub use scheduled::{DelayCompInfo, ScheduledNode};
 
 #[cfg(test)]
 mod tests {

--- a/src/output_ir.rs
+++ b/src/output_ir.rs
@@ -80,9 +80,9 @@ pub struct BufferAssignment {
     /// passing it to a process
     pub should_clear: bool,
     /// The ID of the port this buffer is mapped to
-    pub port_id: usize,
+    pub port_id: u64,
     /// The ID of the node this buffer is mapped to
-    pub node_id: usize,
+    pub node_id: u64,
     /// Buffers are reused, the "generation" represnts
     /// how many times this buffer has been used before
     /// this assignment. Kept for debugging and visualization.

--- a/src/output_ir.rs
+++ b/src/output_ir.rs
@@ -1,0 +1,90 @@
+//! Output data structures from the audio graph compiler.
+//!
+use crate::input_ir::Edge;
+use serde::{Deserialize, Serialize};
+
+/// A [CompiledSchedule] is the output of the graph compiler.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CompiledSchedule {
+    /// A list of nodes, delays, and summing points to
+    /// evaluate in order to render audio, in topological order.
+    pub schedule: Vec<ScheduleEntry>,
+    /// A list of delays that were inserted into the graph.
+    pub delays: Vec<InsertedDelay>,
+    /// The total number of buffers required to allocate, for
+    /// each type of port.
+    pub num_buffers: Vec<usize>,
+}
+
+/// A [ScheduleEntry] is one element of the schedule to evalute.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ScheduleEntry {
+    /// One of the input nodes, to process
+    Node(ScheduledNode),
+    /// A delay that was inserted for latency compensation
+    Delay(InsertedDelay),
+    /// A sum that was inserted to merge multiple inputs into
+    /// the same port.
+    Sum(InsertedSum),
+}
+
+/// A [ScheduledNode] is a [Node] that has been assigned buffers
+/// and a place in the schedule.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScheduledNode {
+    /// The unique ID of this node.
+    pub id: u64,
+    /// The latency of this node. Kept for debugging and visualization.
+    pub latency: f64,
+    /// The assigned input buffers.
+    pub input_buffers: Vec<BufferAssignment>,
+    /// The assigned output buffers.
+    pub output_buffers: Vec<BufferAssignment>,
+}
+
+/// An [InsertedDelay] represents a required delay node to be inserted
+/// along some edge in order to compensate for different latencies along
+/// paths of the graph.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct InsertedDelay {
+    /// The edge that this delay corresponds to. Kept for debugging and visualization.
+    pub edge: Edge,
+    /// The amount of delay to apply to the input.
+    pub delay: f64,
+    /// The input data to read.
+    pub input_buffer: BufferAssignment,
+    /// The output buffer to write delayed into to.
+    pub output_buffer: BufferAssignment,
+}
+
+/// An [InsertedSum] represents a point where multiple edges need to be merged
+/// into a single buffer, in order to support multiple inputs into the same
+/// port.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct InsertedSum {
+    /// The input buffers that will be summed
+    pub input_buffers: Vec<BufferAssignment>,
+    /// The output buffer to write to
+    pub output_buffer: BufferAssignment,
+}
+
+/// A [Buffer Assignment] represents a single buffer assigned to an input
+/// or output port.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct BufferAssignment {
+    /// The index of the buffer assigned
+    pub buffer_index: usize,
+    /// The index of the type of data in this buffer
+    pub type_index: usize,
+    /// Whether the engine should clear the buffer before
+    /// passing it to a process
+    pub should_clear: bool,
+    /// The ID of the port this buffer is mapped to
+    pub port_id: usize,
+    /// The ID of the node this buffer is mapped to
+    pub node_id: usize,
+    /// Buffers are reused, the "generation" represnts
+    /// how many times this buffer has been used before
+    /// this assignment. Kept for debugging and visualization.
+    pub generation: usize,
+}

--- a/src/port_type.rs
+++ b/src/port_type.rs
@@ -3,7 +3,7 @@ use std::fmt;
 /// An abstract port type.
 pub trait PortType
 where
-    Self: fmt::Debug + Clone + Copy + Eq + std::hash::Hash,
+    Self: Default + fmt::Debug + Clone + Copy + Eq + std::hash::Hash,
 {
     /// The total number of all port types
     const NUM_TYPES: usize;
@@ -18,6 +18,12 @@ pub enum DefaultPortType {
     Audio,
     /// Event (non-audio) ports
     Event,
+}
+
+impl Default for DefaultPortType {
+    fn default() -> Self {
+        DefaultPortType::Audio
+    }
 }
 
 impl PortType for DefaultPortType {

--- a/src/scheduled.rs
+++ b/src/scheduled.rs
@@ -3,18 +3,6 @@ use smallvec::SmallVec;
 use crate::buffer_allocator::Buffer;
 use crate::port_type::PortType;
 
-/// The compiled schedule
-#[derive(Clone, Debug, Default)]
-pub struct Schedule<N, P, PT>
-where
-    PT: PortType,
-{
-    /// The scheduled nodes in sequential order
-    pub scheduled: Vec<ScheduledNode<N, P, PT>>,
-    // TODO: Put the total number of each type of buffer the user needs
-    // to allocate here for convenience?
-}
-
 /// A scheduled node is a node with buffers assigned to its input and output ports
 #[derive(Clone, Debug)]
 pub struct ScheduledNode<N, P, PT>

--- a/src/scheduled.rs
+++ b/src/scheduled.rs
@@ -1,17 +1,41 @@
 use crate::buffer_allocator::Buffer;
 use crate::port_type::PortType;
 use crate::vec::Vec;
+use crate::{NodeRef, PortRef};
+
+/// The compiled schedule
+#[derive(Clone, Debug, Default)]
+pub struct Schedule<PT>
+where
+    PT: PortType,
+{
+    /// The scheduled nodes in sequential order
+    pub scheduled: Vec<ScheduledNode<PT>>,
+    // TODO: Put the total number of each type of buffer the user needs
+    // to allocate here for convenience?
+}
 
 /// A scheduled node is a node with buffers assigned to its input and output ports
 #[derive(Clone, Debug)]
-pub struct ScheduledNode<N, P, PT>
+pub struct ScheduledNode<PT>
 where
     PT: PortType,
 {
     /// The node itself
-    pub node: N,
+    pub node: NodeRef,
     /// A list of input buffers assigned to ports
-    pub inputs: Vec<(P, Vec<(Buffer<PT>, u64)>)>,
+    pub inputs: Vec<(PortRef, Vec<(Buffer<PT>, Option<DelayCompInfo>)>)>,
     // A list of output buffers assigned to ports
-    pub outputs: Vec<(P, Buffer<PT>)>,
+    pub outputs: Vec<(PortRef, Buffer<PT>)>,
+}
+
+/// Information on delay compensation
+#[derive(Clone, Debug)]
+pub struct DelayCompInfo {
+    /// The delay compensation in frames
+    pub delay: u64,
+    /// The source node of this connection
+    pub source_node: NodeRef,
+    /// The source port of this connection
+    pub source_port: PortRef,
 }

--- a/src/scheduled.rs
+++ b/src/scheduled.rs
@@ -1,41 +1,47 @@
+use smallvec::SmallVec;
+
 use crate::buffer_allocator::Buffer;
 use crate::port_type::PortType;
-use crate::vec::Vec;
-use crate::{NodeRef, PortRef};
 
 /// The compiled schedule
 #[derive(Clone, Debug, Default)]
-pub struct Schedule<PT>
+pub struct Schedule<N, P, PT>
 where
     PT: PortType,
 {
     /// The scheduled nodes in sequential order
-    pub scheduled: Vec<ScheduledNode<PT>>,
+    pub scheduled: Vec<ScheduledNode<N, P, PT>>,
     // TODO: Put the total number of each type of buffer the user needs
     // to allocate here for convenience?
 }
 
 /// A scheduled node is a node with buffers assigned to its input and output ports
 #[derive(Clone, Debug)]
-pub struct ScheduledNode<PT>
+pub struct ScheduledNode<N, P, PT>
 where
     PT: PortType,
 {
     /// The node itself
-    pub node: NodeRef,
+    pub node: N,
+
+    // Note that these SmallVecs will actually be allocated on the heap (inside a
+    // std Vec of ScheduledNodes). SmallVecs can still be useful here since the
+    // majority of nodes on average will have less the 5 inputs/outputs and atleast
+    // one or two buffesr per input port, so all that memory allocated upfront will
+    // avoid a bunch of smaller allocations when filling in the schedule later.
     /// A list of input buffers assigned to ports
-    pub inputs: Vec<(PortRef, Vec<(Buffer<PT>, Option<DelayCompInfo>)>)>,
+    pub inputs: SmallVec<[(P, SmallVec<[(Buffer<PT>, Option<DelayCompInfo<N, P>>); 2]>); 4]>,
     // A list of output buffers assigned to ports
-    pub outputs: Vec<(PortRef, Buffer<PT>)>,
+    pub outputs: SmallVec<[(P, Buffer<PT>); 4]>,
 }
 
 /// Information on delay compensation
 #[derive(Clone, Debug)]
-pub struct DelayCompInfo {
+pub struct DelayCompInfo<N, P> {
     /// The delay compensation in frames
     pub delay: u64,
     /// The source node of this connection
-    pub source_node: NodeRef,
+    pub source_node: N,
     /// The source port of this connection
-    pub source_port: PortRef,
+    pub source_port: P,
 }


### PR DESCRIPTION
I realized that additional information like the source node/port is needed to know when to re-use delay compensation nodes when recompiling the graph.

Also, while adding the extra info, it managed to panic because of a stack overflow. I think this is partly due to how the schedule takes user-defined-types for node/port ids, and those types can potentially be large (like a string or a complex enum). So I replaced it to use the previous NodeRef/PortRef system you had before, and it seems to be working again. Although we should still probably look into reducing the amount of data on the stack by either making the SmallVecs smaller or by making the IDs smaller (32bit ids instead of 64bit).

I also had to take the schedule out of the graph struct because it was giving me a borrow check error when trying to use `graph.port_ident()` and `graph.node_ident()`.